### PR TITLE
fix python's implementation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You will need to generate an API Key. Every API Key is tied to a specific Shape.
 ### 🐍 Python
 
 ```python
-import openai
+from openai import OpenAI
 
 shapes_client = OpenAI(
     api_key="<your-API-key>",


### PR DESCRIPTION
In python's implementation example, the import was incorrect
Before: `import openai`
Now: `from openai import OpenAI`