### PR TITLE
Add image and audio attachment support to Revolt example

### DIFF
--- a/examples/social/shape-revolt/.env.example
+++ b/examples/social/shape-revolt/.env.example
@@ -1,6 +1,6 @@
 # Revolt Bot Token - Get this from the Revolt Developer Portal
 REVOLT_TOKEN=your-revolt-bot-token
-
+REVOLT_SERVER_URL= # Default revolt media server is https://autumn.revolt.chat
 # Shapes API Configuration
 SHAPESINC_API_KEY=your-shapes-api-key
 SHAPESINC_SHAPE_USERNAME=your-shape-username 

--- a/examples/social/shape-revolt/README.md
+++ b/examples/social/shape-revolt/README.md
@@ -8,6 +8,8 @@ An integration for [Revolt](https://revolt.chat) that allows your Shape (social 
 - Automatically handles direct messages sent to your Shape
 - Connects to the Revolt Websocket API for real-time communication
 - Uses Shapes API with OpenAI-compatible client for your Shape's responses
+- Supports image and audio attachments for multimodal conversations
+- Processes media files and sends them to Shapes API for analysis
 
 ## Prerequisites
 
@@ -36,6 +38,7 @@ An integration for [Revolt](https://revolt.chat) that allows your Shape (social 
    REVOLT_TOKEN=your-revolt-bot-token
    SHAPESINC_API_KEY=your-shapes-api-key
    SHAPESINC_SHAPE_USERNAME=your-shape-username
+   REVOLT_SERVER_URL=https://autumn.revolt.chat  # Optional: Override default server URL for attachments
    ```
 
    ## Picture Guide to Setup
@@ -58,32 +61,23 @@ An integration for [Revolt](https://revolt.chat) that allows your Shape (social 
 
 3. You can also DM your Shape directly, and it will respond to all messages.
 
+4. Send images or audio files with your messages to enable multimodal conversations:
+   ```
+   @YourShape What do you think of this picture?
+   [attach an image]
+   ```
+
 ## How it Works
 
 This integration uses the Revolt WebSocket API to provide your Shape with real-time message capabilities. When your Shape is mentioned or receives a DM, the integration:
 
 1. Extracts the user's message
-2. Sends the message to the Shapes API using your Shape's identity
-3. Returns your Shape's response back to the Revolt chat
+2. Processes any attached images or audio files
+3. Formats the content appropriately for multimodal API requests
+4. Sends the message and media to the Shapes API using your Shape's identity
+5. Returns your Shape's response back to the Revolt chat
 
 ## Customization
 
 You can use any of your Shapes by changing the `SHAPESINC_SHAPE_USERNAME` in your `.env` file. This allows you to give any of your Shapes a presence on Revolt. 
-
-
-
-
-# Sorayai's Updates
-## -Added picture guide for Revolt bot token + .env setup
-
-## -Updating index.js
-   1-Added code for debugging
-   
-   2-Added code to fix error: 
-  status: 400,
-  data: !DOCTYPE html
-    
-  3-Added chunking code so Shapes on Revolt don't error out when sending long messages 
-    
- 
 

--- a/examples/social/shape-revolt/README.md
+++ b/examples/social/shape-revolt/README.md
@@ -58,8 +58,16 @@ An integration for [Revolt](https://revolt.chat) that allows your Shape (social 
    ```
    @YourShape How are you today?
    ```
+   
+   **Example of chat in server:**
+   
+   ![Example of chat in server](https://img.intercomm.in/wy1epy.png)
 
 3. You can also DM your Shape directly, and it will respond to all messages.
+
+   **Example of chat in DM:**
+   
+   ![Example of chat in DM](https://img.intercomm.in/fxb7t9.png)
 
 4. Send images or audio files with your messages to enable multimodal conversations:
    ```
@@ -80,4 +88,3 @@ This integration uses the Revolt WebSocket API to provide your Shape with real-t
 ## Customization
 
 You can use any of your Shapes by changing the `SHAPESINC_SHAPE_USERNAME` in your `.env` file. This allows you to give any of your Shapes a presence on Revolt. 
-


### PR DESCRIPTION
## Why  
Our revolt.chat example was missing image vision and voice messages support – which doesn't showcase the full potential of our API.

## What Changed  
Added image and audio attachment processing to the Revolt example, including:  
- Added revolt media server in imports
- Extraction of image/audio URLs from attachments  
- Support for multimodal content formatting for the Shapes API  
- Enhanced message handling for media files  
- Default placeholder text for empty messages with attachments

## Test Plan  
Tested locally with both image and audio messages. The bot correctly:  
- Detects and processes attachments  
- Formats multimodal content for API requests  
- Maintains original text-only functionality

## Integration Details  
- Integration Type: Platform (Revolt)  
- Example Code Added: Yes

## Screenshots/Examples  
![image](https://github.com/user-attachments/assets/c9b77058-fd0b-47a5-94c7-8484455cf6d3)
![image](https://github.com/user-attachments/assets/73683963-5af0-4d79-b350-c270f311928e)


## Checklist  
- [x] I have tested my changes locally  
- [x] My code follows the project's base guidelines  
- [x] I have updated relevant documentation  
- [x] I have added appropriate error handling  
- [x] I have considered security implications

